### PR TITLE
Support space

### DIFF
--- a/ext/strptime/strptime.c
+++ b/ext/strptime/strptime.c
@@ -220,7 +220,11 @@ LABEL_PTR(u), LABEL_PTR(v), LABEL_PTR(w), LABEL_PTR(x), LABEL_PTR(y), LABEL_PTR(
 	    fail();
 	ADD_PC(1);
     END_INSN(m)}
-    INSN_ENTRY(n){ END_INSN(n)}
+    INSN_ENTRY(n){
+  while (ISSPACE((unsigned char)str[si])
+      si++;
+  ADD_PC(1);
+    END_INSN(n)}
     INSN_ENTRY(p){ END_INSN(p)}
     INSN_ENTRY(r){ END_INSN(r)}
     INSN_ENTRY(s){ END_INSN(s)}

--- a/spec/strptime_spec.rb
+++ b/spec/strptime_spec.rb
@@ -101,4 +101,11 @@ describe Strptime do
     expect(pr.exec("20150610102415").utc_offset).to eq(0)
     expect(pr.exec("20150610102415").utc_offset).to eq(0)
   end
+
+  it 'parses %Y-%m-%d %H:%M:%S' do
+    pr = Strptime.new("%Y-%m-%d %H:%M:%S")
+    expect(pr.exec("2015-06-10 10:24:15").to_i).to eq(1433931855)
+    expect(pr.exec("2015-06-10 10:24:15").utc_offset).to eq(0)
+    expect(pr.exec("2015-06-10 10:24:15").utc_offset).to eq(0)
+  end
 end


### PR DESCRIPTION
Closes #1

Fixed this particular case.
But I have read the source code and understood `strptime` doesn't many other formats yet...