### PR TITLE
Strftime: Result string encoding should be same with given format to follow Time#strftime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ rvm:
   - 2.2.4-clang
   - 2.3.0
   - 2.3.0-clang
+  - 2.4.2
+  - 2.4.2-clang
   - ruby-head
 matrix:
   allow_failures:

--- a/ext/strptime/strftime.c
+++ b/ext/strptime/strftime.c
@@ -74,7 +74,7 @@ strftime_exec0(void **pc, VALUE fmt, struct timespec *tsp, int gmtoff, size_t re
 	return Qnil;
     }
 
-    result = rb_str_new(NULL, result_length);
+    result = rb_enc_str_new(NULL, result_length, rb_enc_get(fmt));
     p = RSTRING_PTR(result);
 
     tsp->tv_sec += gmtoff;

--- a/ext/strptime/strftime.c
+++ b/ext/strptime/strftime.c
@@ -491,5 +491,7 @@ Init_strftime(void)
     rb_define_method(rb_cStrftime, "exec", strftime_exec, 1);
     rb_define_method(rb_cStrftime, "execi", strftime_execi, 1);
     rb_define_method(rb_cStrftime, "source", strftime_source, 0);
+#ifndef HAVE_RB_TIME_UTC_OFFSET
     id_gmtoff = rb_intern("gmtoff");
+#endif
 }

--- a/spec/strftime_spec.rb
+++ b/spec/strftime_spec.rb
@@ -108,4 +108,12 @@ describe Strftime do
     t = Time.now.utc
     expect(gr.execi(t.to_f)).to eq(t.strftime("%Y-%m-%dT%H:%M:%S.%LZ"))
   end
+
+  describe 'result encoding' do
+    it 'is same with given format encoding' do
+      format = "%Y".force_encoding(Encoding::UTF_8)
+      gr = Strftime.new(format)
+      expect(gr.exec(Time.utc(2015)).encoding).to eq(format.encoding)
+    end
+  end
 end


### PR DESCRIPTION
This affects serialization result, e.g. msgpack separates bin/str.