### PR TITLE
Raise an error if there are extra characters

### DIFF
--- a/ext/strptime/strptime.c
+++ b/ext/strptime/strptime.c
@@ -366,6 +366,7 @@ strptime_exec0(void **pc, const char *fmt, const char *str, size_t slen,
 	int r;
 	size_t len;
 	if (*p0 == 'z' || *p0 == 'Z') {
+	    si++;
 	    gmtoff = 0;
 	    ADD_PC(1);
 	    END_INSN(z)
@@ -417,6 +418,8 @@ strptime_exec0(void **pc, const char *fmt, const char *str, size_t slen,
     }
     INSN_ENTRY(_5f)
     {
+	if (si != slen) fail();
+
 	struct timespec ts;
 	struct tm tm;
 	time_t t;

--- a/spec/strptime_spec.rb
+++ b/spec/strptime_spec.rb
@@ -212,4 +212,8 @@ describe Strptime do
       expect(pr.exec('2016-12-11 00:00:00')).to eq(Time.local(2016,12,11,0,0,0))
     end
   end
+
+  it 'raises with extra characters' do
+    expect{Strptime.new('%Y-%m-%d %H:%M:%S').exec('2020-05-11 01:23:45+09:00')}.to raise_error
+  end
 end


### PR DESCRIPTION
I believe most developers don't expect `Strptime.new('%Y-%m-%d %H:%M:%S')` to parse a string with a timezone, so it should raise an error.
`Time.strptime('2020-05-11 01:23:45+09:00', '%Y-%m-%d %H:%M:%S')` returns "2020-05-11 01:23:45 +0000", though.