### PR TITLE
Parse "Z" as UTC

### DIFF
--- a/ext/strptime/strptime.c
+++ b/ext/strptime/strptime.c
@@ -366,7 +366,7 @@ strptime_exec0(void **pc, const char *fmt, const char *str, size_t slen,
 	int r;
 	size_t len;
 	if (*p0 == 'z' || *p0 == 'Z') {
-	    gmtoff = 0;
+	    gmtoff = INT_MAX-1;
 	    ADD_PC(1);
 	    END_INSN(z)
 	}

--- a/spec/strptime_spec.rb
+++ b/spec/strptime_spec.rb
@@ -171,6 +171,9 @@ describe Strptime do
     expect(Strptime.new("%z").exec("+09:00").utc_offset).to eq(32400)
     expect(Strptime.new("%z").exec("+09:30").utc_offset).to eq(34200)
     expect(Strptime.new("%z").exec("Z").utc_offset).to eq(0)
+    expect(Strptime.new("%z").exec("Z")).to be_utc
+    expect(Strptime.new("%z").exec("+00:00").utc_offset).to eq(0)
+    expect(Strptime.new("%z").exec("+00:00")).not_to be_utc
   end
 
   ## from test/test_time.rb


### PR DESCRIPTION
I think it is convenient to parse "Z" as UTC.
In addition, I guess this change should have been included in the commit  dae8e5c97d47c4e594bf850f72d212f1c49dbff5.