### PR TITLE
Relax ruby version constraint to support ruby3

### DIFF
--- a/strptime.gemspec
+++ b/strptime.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.extensions    = ["ext/strptime/extconf.rb"]
-  spec.required_ruby_version = '~> 2.0'
+  spec.required_ruby_version = '>= 2.0'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
I tested with ruby3.0.0-preview1 and no problem.

This blocks fluentd install for ruby3.